### PR TITLE
Check for iQue Player in cart_init

### DIFF
--- a/src/cart/cartinit.c
+++ b/src/cart/cartinit.c
@@ -1,6 +1,18 @@
 #include <cart.h>
 #include "cartint.h"
 
+#define MI_VERSION ((volatile uint32_t*)0xA4300004)
+
+static int cart_bbplayer(void)
+{
+	static int bbplayer = -1;
+	if (bbplayer == -1)
+	{
+		bbplayer = (*MI_VERSION & 0xF0) == 0xB0;
+	}
+	return bbplayer;
+}
+
 int cart_type = CART_NULL;
 
 int cart_init(void)
@@ -14,6 +26,11 @@ int cart_init(void)
 	};
 	int i;
 	int result;
+	// On iQue, touching PI addresses outside mapped ROM triggers a bus error
+	if (cart_bbplayer())
+	{
+		return -1;
+	}
 	if (!__cart_dom1)
 	{
 		__cart_dom1 = 0x8030FFFF;

--- a/src/cart/cartinit.c
+++ b/src/cart/cartinit.c
@@ -2,16 +2,7 @@
 #include "cartint.h"
 
 #define MI_VERSION ((volatile uint32_t*)0xA4300004)
-
-static int cart_bbplayer(void)
-{
-	static int bbplayer = -1;
-	if (bbplayer == -1)
-	{
-		bbplayer = (*MI_VERSION & 0xF0) == 0xB0;
-	}
-	return bbplayer;
-}
+#define cart_bbplayer() ((*MI_VERSION & 0xF0) == 0xB0)
 
 int cart_type = CART_NULL;
 


### PR DESCRIPTION
iQue will fail catastrophically if libcart attempts to probe memory beyond the mapped ROM.

This check prevents this bus error from being triggered, and just returns a -1 error code as if the cart type had not been detected.