### PR TITLE
Early return on cart_init if already initialized

### DIFF
--- a/include/cart.h
+++ b/include/cart.h
@@ -9,6 +9,7 @@ typedef uint32_t u32;
 #endif
 
 /* Cartridge types */
+#define CART_UNDEFINED  -2
 #define CART_NULL       -1
 #define CART_CI         0       /* 64Drive */
 #define CART_EDX        1       /* EverDrive-64 X-series */

--- a/src/cart/cartexit.c
+++ b/src/cart/cartexit.c
@@ -10,6 +10,11 @@ int cart_exit(void)
 		ed_exit,
 		sc_exit,
 	};
-	if (cart_type < 0) return -1;
-	return exit[cart_type]();
+	int result = -1;
+	if (cart_type >= 0)
+	{
+		result = exit[cart_type]();
+	}
+	cart_type = CART_UNDEFINED;
+	return result;
 }


### PR DESCRIPTION
Disambiguates the undefined vs null detection states.

[Link to n64Brew Discord conversation in #libdragon-dev](https://discord.com/channels/205520502922543113/974342113850445874/1331407222311489619) 